### PR TITLE
Rename integration to match metadata slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# analytics.js-integration-customerio [![Build Status][ci-badge]][ci-link]
+# analytics.js-integration-customer-io [![Build Status][ci-badge]][ci-link]
 
-Customerio integration for [Analytics.js][].
+Customer.io integration for [Analytics.js][].
 
 ## License
 
@@ -8,5 +8,5 @@ Released under the [MIT license](LICENSE).
 
 
 [Analytics.js]: https://segment.com/docs/libraries/analytics.js/
-[ci-link]: https://circleci.com/gh/segment-integrations/analytics.js-integration-customerio
-[ci-badge]: https://circleci.com/gh/segment-integrations/analytics.js-integration-customerio.svg?style=svg
+[ci-link]: https://circleci.com/gh/segment-integrations/analytics.js-integration-customer-io
+[ci-badge]: https://circleci.com/gh/segment-integrations/analytics.js-integration-customer-io.svg?style=svg

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@segment/analytics.js-integration-customerio",
+  "name": "@segment/analytics.js-integration-customer-io",
   "description": "The Customerio analytics.js integration.",
   "version": "2.0.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
     "segment",
-    "customerio"
+    "customer.io"
   ],
   "main": "lib/index.js",
   "scripts": {
@@ -14,14 +14,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/segment-integrations/analytics.js-integration-customerio.git"
+    "url": "git+https://github.com/segment-integrations/analytics.js-integration-customer-io.git"
   },
   "author": "Segment <friends@segment.com>",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
-    "url": "https://github.com/segment-integrations/analytics.js-integration-customerio/issues"
+    "url": "https://github.com/segment-integrations/analytics.js-integration-customer-io/issues"
   },
-  "homepage": "https://github.com/segment-integrations/analytics.js-integration-customerio#readme",
+  "homepage": "https://github.com/segment-integrations/analytics.js-integration-customer-io#readme",
   "dependencies": {
     "@segment/alias": "^1.0.2",
     "@segment/analytics.js-integration": "^2.1.0",


### PR DESCRIPTION
After merging this we should:
- Run `npm deprecate @segment/analytics.js-integration-customerio "@segment/analytics.js-integration-customerio has been renamed. Use @segment/analytics.js-integration-customer-io instead."`
- Rename this repository to `analytics.js-integration-customerio`
- Issue a `3.0.0` release
